### PR TITLE
[Fix] 행사 설명에 개행이 적용 안되는 버그 수정

### DIFF
--- a/src/components/FormDescription.tsx
+++ b/src/components/FormDescription.tsx
@@ -22,8 +22,7 @@ const FormDescription = ({
 
   return (
     <Text
-      as={"pre"}
-      style={{ width: "100%" }}
+      style={{ width: "100%", whiteSpace: "break-spaces" }}
       typo={isMobile ? "body2" : "body1"}
     >
       {!isNaN(startDate.getTime()) && `행사 일시: ${showDate}`}

--- a/src/components/FormDescription.tsx
+++ b/src/components/FormDescription.tsx
@@ -21,7 +21,11 @@ const FormDescription = ({
   }월 ${startDate.getDate()}일 ${startDate.getHours()}시 ${startDate.getMinutes()}분`;
 
   return (
-    <Text style={{ width: "100%" }} typo={isMobile ? "body2" : "body1"}>
+    <Text
+      as={"pre"}
+      style={{ width: "100%" }}
+      typo={isMobile ? "body2" : "body1"}
+    >
       {!isNaN(startDate.getTime()) && `행사 일시: ${showDate}`}
       <br />
       {venue && `행사 장소: ${venue}`}


### PR DESCRIPTION
## 🎉 변경 사항
**행사 설명란에 개행이 제대로 반영되지 않던 버그 수정**
- 설명란의 Text 컴포넌트를 p태그에서 pre태그로 변경했습니다.

## 🚩 관련 이슈

## 🙏 여기는 꼭 봐주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일 개선**
  * 폼 설명 텍스트의 형식 표현이 개선되었습니다.
  * 설명이 장소 정보 아래에 더 명확하게 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->